### PR TITLE
Remove unnecessary string-padding from Commands

### DIFF
--- a/RxLifxApi/RxLifxApi/Command/DeviceSetGroupCommand.swift
+++ b/RxLifxApi/RxLifxApi/Command/DeviceSetGroupCommand.swift
@@ -24,7 +24,7 @@ import RxSwift
 
 public class DeviceSetGroupCommand {
     public class func create(light: Light, group: [UInt8], label: String, updatedAt:Date = Date(), ackRequired: Bool = false, responseRequired: Bool = false) -> Observable<Result<StateGroup>> {
-        let group = LightGroup(id: group.pad(length: 16, e: 48), label: label.padding(toLength: 32, withPad: "", startingAt: 0), updatedAt: updatedAt)
+        let group = LightGroup(id: group.pad(length: 16, e: 48), label: label, updatedAt: updatedAt)
         let message = Message.createMessageWithPayload(SetGroup(group: group.id, label: group.label, updated_at: UInt64(group.updatedAt.timeIntervalSince1970 * 100_000_000)), target: light.target, source: light.lightSource.source)
         message.header.ackRequired = ackRequired
         message.header.responseRequired = responseRequired

--- a/RxLifxApi/RxLifxApi/Command/DeviceSetLabelCommand.swift
+++ b/RxLifxApi/RxLifxApi/Command/DeviceSetLabelCommand.swift
@@ -24,7 +24,6 @@ import RxSwift
 
 public class DeviceSetLabelCommand {
     public class func create(light: Light, label: String, ackRequired: Bool = false, responseRequired: Bool = false) -> Observable<Result<StateLabel>> {
-        let label = label.padding(toLength: 32, withPad: "", startingAt: 0)
         let message = Message.createMessageWithPayload(SetLabel(label: label), target: light.target, source: light.lightSource.source)
         message.header.ackRequired = ackRequired
         message.header.responseRequired = responseRequired

--- a/RxLifxApi/RxLifxApi/Command/DeviceSetLocationCommand.swift
+++ b/RxLifxApi/RxLifxApi/Command/DeviceSetLocationCommand.swift
@@ -24,7 +24,7 @@ import RxSwift
 
 public class DeviceSetLocationCommand {
     public class func create(light: Light, location: [UInt8], label: String, updatedAt:Date = Date(), ackRequired: Bool = false, responseRequired: Bool = false) -> Observable<Result<StateLocation>> {
-        let location = LightLocation(id: location.pad(length: 16, e: 48), label: label.padding(toLength: 32, withPad: "", startingAt: 0), updatedAt: updatedAt)
+        let location = LightLocation(id: location.pad(length: 16, e: 48), label: label, updatedAt: updatedAt)
         let message = Message.createMessageWithPayload(SetLocation(location: location.id, label: location.label, updated_at: UInt64(location.updatedAt.timeIntervalSince1970 * 100_000_000)), target: light.target, source: light.lightSource.source)
         message.header.ackRequired = ackRequired
         message.header.responseRequired = responseRequired


### PR DESCRIPTION
Three commands (SetGroup, SetLabel, SetLocation) were calling something like .padding(toLength: 32, withPad: "", startingAt: 0) which is not necessary because DataOutputStream already takes a length for writeString and pads appropriately.

```
    func writeString(value:String, size:Int){
        let padding = size - value.utf8.count
        for _ in 0..<padding{
            writeByte(value: 20)
        }
        value.utf8.forEach{ writeByte(value: UInt8($0)) }
    }
```
Also, if the string passed into any of these commands actually was too short, it would result in a crash, which you can reproduce by pasting the following line into a Swift Playground (can't actually pad with an empty string like that)
```
let padded = "Hello World".padding(toLength: 32, withPad: "", startingAt: 0)
```
With this fix, I am able to properly rename bulbs now in my host app.