### PR TITLE
Initial Cocoapods support

### DIFF
--- a/LifxDomain.podspec
+++ b/LifxDomain.podspec
@@ -1,0 +1,21 @@
+Pod::Spec.new do |s|
+  s.name         = "LifxDomain"
+  s.version      = "0.0.1"
+
+  s.summary      = "LIFX Message definition and (de)serialization code for integration with your own code. Has no external dependencies."
+  s.description  = <<-DESC
+                   Part of the RxLifx-Swift set of frameworks
+                   DESC
+
+  s.homepage     = "https://github.com/flowsprenger/RxLifx-Swift"
+  s.license      = 'MIT'
+  s.author       = 'Florian Sprenger'
+
+  s.ios.deployment_target = '9.0'
+  s.tvos.deployment_target = '9.0'
+  s.watchos.deployment_target = '3.2'
+
+  s.source       = { :git => "https://github.com/lightbow/RxLifx-Swift.git" }
+
+  s.source_files = 'LifxDomain/LifxDomain/*.{h,swift}'
+end

--- a/LifxDomain.podspec
+++ b/LifxDomain.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '9.0'
   s.watchos.deployment_target = '3.2'
 
-  s.source       = { :git => "https://github.com/lightbow/RxLifx-Swift.git" }
+  s.source       = { :git => "https://github.com/flowsprenger/RxLifx-Swift.git" }
 
   s.source_files = 'LifxDomain/LifxDomain/*.{h,swift}'
 end

--- a/RxLifx.podspec
+++ b/RxLifx.podspec
@@ -1,0 +1,23 @@
+Pod::Spec.new do |s|
+  s.name         = "RxLifx"
+  s.version      = "0.0.1"
+
+  s.summary      = "Networking code to communicate with LIFX lights on the local LAN using UDP packets."
+  s.description  = <<-DESC
+                   Part of the RxLifx-Swift set of frameworks
+                   DESC
+
+  s.homepage     = "https://github.com/flowsprenger/RxLifx-Swift"
+  s.license      = 'MIT'
+  s.author       = 'Florian Sprenger'
+
+  s.ios.deployment_target = '9.0'
+  s.tvos.deployment_target = '9.0'
+  s.watchos.deployment_target = '3.2'
+
+  s.source       = { :git => "https://github.com/lightbow/RxLifx-Swift.git" }
+
+  s.dependency 'RxSwift', '4.1.0'
+
+  s.source_files = 'RxLifx/RxLifx/*.{h,swift}'
+end

--- a/RxLifx.podspec
+++ b/RxLifx.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
 
   s.source       = { :git => "https://github.com/lightbow/RxLifx-Swift.git" }
 
-  s.dependency 'RxSwift', '4.1.0'
+  s.dependency 'RxSwift', '4.1.2'
 
   s.source_files = 'RxLifx/RxLifx/*.{h,swift}'
 end

--- a/RxLifx.podspec
+++ b/RxLifx.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '9.0'
   s.watchos.deployment_target = '3.2'
 
-  s.source       = { :git => "https://github.com/lightbow/RxLifx-Swift.git" }
+  s.source       = { :git => "https://github.com/flowsprenger/RxLifx-Swift.git" }
 
   s.dependency 'RxSwift', '4.1.2'
 

--- a/RxLifxApi.podspec
+++ b/RxLifxApi.podspec
@@ -1,0 +1,25 @@
+Pod::Spec.new do |s|
+  s.name         = "RxLifxApi"
+  s.version      = "0.0.1"
+
+  s.summary      = "Simple Api demonstrating usage RxLifx and LifxDomain"
+  s.description  = <<-DESC
+                   Part of the RxLifx-Swift set of frameworks
+                   DESC
+
+  s.homepage     = "https://github.com/flowsprenger/RxLifx-Swift"
+  s.license      = 'MIT'
+  s.author       = 'Florian Sprenger'
+
+  s.ios.deployment_target = '9.0'
+  s.tvos.deployment_target = '9.0'
+  s.watchos.deployment_target = '3.2'
+
+  s.source       = { :git => "https://github.com/lightbow/RxLifx-Swift.git" }
+
+  s.dependency 'RxSwift', '4.1.0'
+  s.dependency 'RxLifx'
+  s.dependency 'LifxDomain'
+
+  s.source_files = 'RxLifxApi/RxLifxApi/*.{h,swift}', 'RxLifxApi/RxLifxApi/Command/*.swift'
+end

--- a/RxLifxApi.podspec
+++ b/RxLifxApi.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '9.0'
   s.watchos.deployment_target = '3.2'
 
-  s.source       = { :git => "https://github.com/lightbow/RxLifx-Swift.git" }
+  s.source       = { :git => "https://github.com/flowsprenger/RxLifx-Swift.git" }
 
   s.dependency 'RxSwift', '4.1.2'
   s.dependency 'RxLifx'

--- a/RxLifxApi.podspec
+++ b/RxLifxApi.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
 
   s.source       = { :git => "https://github.com/lightbow/RxLifx-Swift.git" }
 
-  s.dependency 'RxSwift', '4.1.0'
+  s.dependency 'RxSwift', '4.1.2'
   s.dependency 'RxLifx'
   s.dependency 'LifxDomain'
 


### PR DESCRIPTION
While additional work is needed for seamless installation via ```pod 'RxLifx-Swift'```, this at least lets any developers who want to hop onto this project easily integrate RxLifx-Swift with their local setup as a Development Pod pointing to these podspec files. At some point, once we have something stable, we should discuss version numbering policy, and if there's interest, potentially listing this as a real CocoaPod and updating the readme.